### PR TITLE
Potential fix for code scanning alert no. 1: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/server/src/modules/device/helpers/generateConnectionCode.ts
+++ b/server/src/modules/device/helpers/generateConnectionCode.ts
@@ -10,7 +10,11 @@ export const generateConnectionCode = (): string => {
     const bytes = crypto.randomBytes(6)
 
     for (let i = 0; i < 6; i++) {
-        result += characters.charAt(bytes[i] % characters.length)
+        let byte;
+        do {
+            byte = crypto.randomBytes(1)[0];
+        } while (byte >= 256 - (256 % characters.length));
+        result += characters.charAt(byte % characters.length);
     }
 
     return result


### PR DESCRIPTION
Potential fix for [https://github.com/screenlite/screenlite/security/code-scanning/1](https://github.com/screenlite/screenlite/security/code-scanning/1)

To fix the issue, we need to ensure that the random selection of characters from the `characters` string is unbiased. This can be achieved by discarding random bytes that fall outside the range of values that can be evenly mapped to the `characters` string. Specifically, we will discard any byte value greater than or equal to `256 - (256 % characters.length)` (in this case, `256 - (256 % 22) = 256 - 16 = 240`). This ensures that the modulo operation is applied only to uniformly distributed values, resulting in an unbiased selection.

The fix involves modifying the loop to repeatedly generate random bytes until a valid byte is found, and then using that byte to select a character. This approach ensures that the generated connection code is uniformly random.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
