### PR TITLE
Remove ENCRYPTION_SECRET length requirement, extend default secret

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - screenlite_server_logs:/app/logs
     environment:
       - NODE_ENV=${NODE_ENV:-development}
-      - ENCRYPTION_SECRET=${ENCRYPTION_SECRET:-secret}
+      - ENCRYPTION_SECRET=${ENCRYPTION_SECRET:-SECRETTUNNELSECRETTUNNELTHROUGHTHEMOUNTAINSECRETSECRETSECRETSECRETTUNNEL}
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/screenlite}
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
@@ -128,7 +128,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  
+
   # PostgreSQL Database
   postgres:
     image: postgres:15-alpine

--- a/server/src/infrastructure/encryption/node-encryption.service.ts
+++ b/server/src/infrastructure/encryption/node-encryption.service.ts
@@ -7,9 +7,8 @@ export class NodeEncryptionService implements IEncryptionService {
     private readonly ivLength: number = 12
     private readonly authTagLength: number = 16
 
-    constructor(secretBase64: string) {
-        this.validateSecret(secretBase64)
-        this.key = Buffer.from(secretBase64, 'base64')
+    constructor(envSecret: string) {
+        this.key = Buffer.from(crypto.hash('sha256', envSecret), 'hex')
     }
 
     public async encrypt(plainText: string): Promise<string> {
@@ -56,13 +55,5 @@ export class NodeEncryptionService implements IEncryptionService {
         ])
 
         return decrypted.toString('utf8')
-    }
-
-    private validateSecret(secret: string): void {
-        const keyBuffer = Buffer.from(secret, 'base64')
-
-        if (keyBuffer.length !== 32) {
-            throw new Error('ENCRYPTION_SECRET must be 32 bytes (base64-encoded)')
-        }
     }
 }


### PR DESCRIPTION
Modifies handling of the ENCRYPTION_SECRET environment variable and updates the key derivation logic in the encryption service.

**Encryption secret handling and key derivation:**

* Changed the default value of the `ENCRYPTION_SECRET` in `docker-compose.yml` to a longer and more complex string, improving the default security posture.
* Updates the `NodeEncryptionService` to derive the encryption key from a SHA256 hash of the provided env string (which will always be 32 bytes)
* Removes the now-unnecessary validation logic that enforced the secret to be a 32-byte base64-encoded string.